### PR TITLE
fix issue #24: add internal mongodb fail connection error, add docker healtcheck verification

### DIFF
--- a/docker-compose.develop.yml
+++ b/docker-compose.develop.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.3'
 services:
   # DEVELOPMET: docker-compose.develop.yml
   mozart_frontend:
@@ -25,9 +25,27 @@ services:
     volumes:
       - "./mozartbackend/sourcecode:/api"
       - "/api/node_modules" # Bind to the container internal node_modules
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3001/api/healthcheck"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+      start_period: 10s
+    restart: always
   mozart_mongodb:
     ports:
       - 27017:27017
+  # required to restart docker containers on healthcheck failure:
+  # https://stackoverflow.com/questions/47088261/restarting-an-unhealthy-docker-container-based-on-healthcheck
+  autoheal:
+    restart: always
+    image: willfarrell/autoheal
+    environment:
+      - AUTOHEAL_CONTAINER_LABEL=all
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    networks:
+      - mozart-network
 networks:
   mozart-network:
     driver: bridge

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.3'
 services:
   # PRODUCTION: docker-compose.override.yml
   mozart_frontend:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.3'
 services:
   # mozart_frontend:
   # * PRODUCTION: docker-compose.override.yml

--- a/mozartbackend/Dockerfile
+++ b/mozartbackend/Dockerfile
@@ -4,6 +4,7 @@ COPY ./sourcecode/package*.json ./
 RUN npm ci --only=production
 
 FROM node:10-alpine
+RUN apk add --no-cache curl
 WORKDIR /api
 COPY --from=api /api/node_modules/ ./node_modules/
 COPY ./sourcecode .

--- a/mozartbackend/Dockerfile.develop
+++ b/mozartbackend/Dockerfile.develop
@@ -1,4 +1,5 @@
 FROM node:10-alpine as api
+RUN apk add --no-cache curl
 WORKDIR /api
 COPY ./sourcecode/package*.json ./
 RUN npm ci

--- a/mozartbackend/sourcecode/app.js
+++ b/mozartbackend/sourcecode/app.js
@@ -5,4 +5,6 @@ const app = express();
 
 app.use('/api', routes);
 
+app.use('/api/healthcheck', require('express-healthcheck')());
+
 module.exports = app;

--- a/mozartbackend/sourcecode/package-lock.json
+++ b/mozartbackend/sourcecode/package-lock.json
@@ -1425,6 +1425,11 @@
         "vary": "~1.1.2"
       }
     },
+    "express-healthcheck": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/express-healthcheck/-/express-healthcheck-0.1.0.tgz",
+      "integrity": "sha1-yr7HgSnEy5DNf7iU364huC4nywc="
+    },
     "extend-shallow": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",

--- a/mozartbackend/sourcecode/package.json
+++ b/mozartbackend/sourcecode/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "dotenv": "^6.2.0",
     "express": "^4.16.4",
+    "express-healthcheck": "^0.1.0",
     "lodash": "^4.17.11",
     "moment": "^2.24.0",
     "mongoose": "^5.4.18",

--- a/mozartbackend/sourcecode/start.js
+++ b/mozartbackend/sourcecode/start.js
@@ -2,6 +2,7 @@ const mongoose = require('mongoose');
 require('dotenv').config({ path: '.env' });
 
 const { PORT, DATABASE } = process.env;
+let mongodbErrorCounter = 0;
 
 // MONGOOSE CONNECTION TO MONGO
 mongoose.Promise = global.Promise;
@@ -12,11 +13,17 @@ const connectWithRetry = () =>
 mongoose.connect(DATABASE, { useNewUrlParser: true });
 
 mongoose.connection.on('error', err => {
+  mongodbErrorCounter += 1;
+  if (mongodbErrorCounter >= 10) {
+    console.log('Terminate process, MongoDB Connection Errors exceeded limit');
+    process.exit(1);
+  }
   console.log(`MongoDB Connection Error: ${err}`);
   setTimeout(connectWithRetry, 5000);
 });
 
 mongoose.connection.on('connected', () => {
+  mongodbErrorCounter = 0;
   console.log('--------------------------------------------------');
   console.log(`🚀  MongoDB is Connected...`);
   console.log('--------------------------------------------------\n');


### PR DESCRIPTION
* launch with `./mozart.sh dev build up logs down`
* do not open UI
* do `docker ps` to get healthy status (around 1 minute)
* stop mongodb: `docker stop mozart_mongodb`
* docker ps to check the health (wait around 1 minute or more)
* autoheal should restart the mozart_backend
* start mongodb again: `docker start mozart_mongodb`

NOTE: there are 2 levels of process restart, low level done inside the node.js itself, if mongodb connection errors exceeds 10 times it will exit the process (and container will be restarted because of the docker-compose flag `restart: always`, other high level docker api healthchek validation, using CURL inside the container to check if api responds to http://localhost:3001/api/healthcheck, if this fails (api is stuck) docker will mark it has `unhealthy`... unfortunately docker-compose can not restart in this case, that is why we need autoheal container to do that for us!