### PR TITLE
fix issue #22 #23, allow access to mongodb and mozart_backend ports in dev

### DIFF
--- a/docker-compose.develop.yml
+++ b/docker-compose.develop.yml
@@ -1,9 +1,9 @@
 version: '2.3'
 services:
-  # DEVELOPMET: docker-compose.develop.yml
+  # DEVELOPMET: mozart_frontend
   mozart_frontend:
-    image: mozart_frontend
-    container_name: mozart_frontend
+    image: mozart_frontend_develop
+    container_name: mozart_frontend_develop
     build:
       context: ./mozartfrontend
       dockerfile: Dockerfile.develop
@@ -14,9 +14,10 @@ services:
       - "/usr/src/mozartfrontend/node_modules" # Bind to the container internal node_modules
     networks:
       - mozart-network
+  # DEVELOPMET: mozart_backend
   mozart_backend:
-    image: mozart_backend
-    container_name: mozart_backend
+    image: mozart_backend_develop
+    container_name: mozart_backend_develop
     build:
       context: ./mozartbackend
       dockerfile: Dockerfile.develop
@@ -32,6 +33,8 @@ services:
       retries: 5
       start_period: 10s
     restart: always
+    networks:
+      - mozart-network
   mozart_mongodb:
     ports:
       - 27017:27017

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,14 +1,25 @@
 version: '2.3'
 services:
-  # PRODUCTION: docker-compose.override.yml
+  # PRODUCTION: mozart_frontend
   mozart_frontend:
-    image: mozart_frontend
-    container_name: mozart_frontend
+    image: mozart_frontend_production
+    container_name: mozart_frontend_production
     build:
       context: ./mozartfrontend
       dockerfile: Dockerfile
     ports:
       - 80:80
+    networks:
+      - mozart-network
+  # PRODUCTION: mozart_backend
+  mozart_backend:
+    image: mozart_backend_production
+    container_name: mozart_backend_production
+    build:
+      context: ./mozartbackend
+      dockerfile: Dockerfile
+    # ports:
+    #   - 3001:3001
     networks:
       - mozart-network
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,16 +3,11 @@ services:
   # mozart_frontend:
   # * PRODUCTION: docker-compose.override.yml
   # * DEVELOPMET: docker-compose.develop.yml
-  mozart_backend:
-    image: mozart_backend
-    container_name: mozart_backend
-    build:
-      context: ./mozartbackend
-      dockerfile: Dockerfile
-    # ports:
-    #   - 3001:3001
-    networks:
-      - mozart-network
+  #
+  # mozart_backend:
+  # * PRODUCTION: docker-compose.override.yml
+  # * DEVELOPMET: docker-compose.develop.yml
+  #
   mozart_mongodb:
     image: mongo:4.0.5
     restart: unless-stopped


### PR DESCRIPTION
NOTE: Merge #24 first, it will generate conflicts in here but it should be easier to fix!

frontend and backend containers will now have different image/container name, so it will cache acordantly and will not be required to build when switching (only during the 1st time).

* build both dev/prod envs
  - ./mozart.sh dev build up logs down
  - POSTMAN GET: http://localhost:3001/api/cpuInfo => will respond
  - ./mozart.sh prod build up logs down
  - POSTMAN GET: http://localhost:3001/api/cpuInfo => will *fail* to respond

* alternate between dev/prod without building
  - ./mozart.sh dev up logs down
  - POSTMAN GET: http://localhost:3001/api/cpuInfo => will respond
  - ./mozart.sh prod up logs down
  - POSTMAN GET: http://localhost:3001/api/cpuInfo => will *fail* to respond
